### PR TITLE
Bugfix: validateAccountNumber

### DIFF
--- a/src/validators/account-number-validator.ts
+++ b/src/validators/account-number-validator.ts
@@ -1,8 +1,7 @@
 import { checkMod11ControlDigit } from '../utilities/mod11-utilities';
 
 export function validateAccountNumber( accountNumber: string ) {
-  const validAccountNumberPattern = new RegExp( /\d{11}|\d{4}\.\d{2}\.\d{5}/ );
-  if ( !validAccountNumberPattern.test( accountNumber ) ) {
+  if ( !/\d{11}|\d{4}\.\d{2}\.\d{5}/.test( accountNumber ) ) {
     return false;
   }
 

--- a/src/validators/account-number-validator.ts
+++ b/src/validators/account-number-validator.ts
@@ -1,7 +1,7 @@
 import { getMod11ControlDigit } from '../utilities/mod11-utilities';
 
 export function validateAccountNumber( accountNumber: string ) {
-  let validAccountNumberPattern = new RegExp( '\d{11}|\d{4}\.\d{2}\.\d{5}' );
+  const validAccountNumberPattern = new RegExp( /\d{11}|\d{4}\.\d{2}\.\d{5}/ );
   if ( !validAccountNumberPattern.test( accountNumber ) ) {
     return false;
   }

--- a/src/validators/account-number-validator.ts
+++ b/src/validators/account-number-validator.ts
@@ -1,4 +1,4 @@
-import { getMod11ControlDigit } from '../utilities/mod11-utilities';
+import { checkMod11ControlDigit } from '../utilities/mod11-utilities';
 
 export function validateAccountNumber( accountNumber: string ) {
   const validAccountNumberPattern = new RegExp( /\d{11}|\d{4}\.\d{2}\.\d{5}/ );
@@ -8,5 +8,5 @@ export function validateAccountNumber( accountNumber: string ) {
 
   accountNumber = accountNumber.toString().replace( /\./g, '' );
 
-  return parseInt( accountNumber.charAt( accountNumber.length - 1 ), 10 ) === getMod11ControlDigit( accountNumber );
+  return checkMod11ControlDigit( accountNumber );
 }


### PR DESCRIPTION
FIX: Control digit was not removed before calling `getMod11ControlDigit()`. The other available method `checkMod11ControlDigit()` already does the needed stripping, suggest using that method instead.

Minor cleanup:
Test against regex directly without intermediate variable.